### PR TITLE
updating the deployment.yaml to support draft directly

### DIFF
--- a/charts/javascript/templates/deployment.yaml
+++ b/charts/javascript/templates/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}    
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}

--- a/draft.toml
+++ b/draft.toml
@@ -1,6 +1,6 @@
 [environments]
   [environments.development]
-    name = "Application"
+    name = "application"
     namespace = "default"
     wait = false
     watch = false


### PR DESCRIPTION
here you go, @azooinmyluggage . this makes everything work perfectly in draft. The annotation is needed to do "draft connect". Without it, draft up works, but you have to hit the LB endpoint to see the app.